### PR TITLE
Updated dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
 
   "dependencies": {
-    "request": "2.47.x",
+    "request": "2.67.x",
     "querystring": "0.2.x"
   }
 }


### PR DESCRIPTION
[Snyk](https://snyk.io) reported [a vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in a `request` dep :

```
closure-compiler-service@0.5.0 > request@2.47.0 > hawk@1.1.1
Upgrade direct dependency request@2.47.0 to request@2.59.0 (triggers upgrades to hawk@3.1.3)
```

A simple version bump takes care of it.
