### PR TITLE
fix: package.json main ccs.js to lib/closure-serivce.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "type": "git",
     "url": "git://github.com/gavinhungry/closure-compiler-service.git"
   },
-
-  "main": "ccs.js",
+  "main": "lib/closure-service.js",
   "bin": {
     "closure-service": "bin/closure-service"
   },


### PR DESCRIPTION
If possible, please release 0.6.1.
Without this we are not able to require('closure-compiler-service');
